### PR TITLE
fix: properly import/include es6 base file

### DIFF
--- a/packages/es6/package.json
+++ b/packages/es6/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourcetoad/eslint-config-base-template-es6",
   "version": "1.0.0",
-  "main": "index.config.js",
+  "main": "eslint.config.js",
   "license": "proprietary",
   "repository": {
     "url": "git@github.com:sourcetoad/base-template-configs.git",

--- a/packages/vue/eslint.config.js
+++ b/packages/vue/eslint.config.js
@@ -1,6 +1,6 @@
+import baseTemplateConfigEs6 from '@sourcetoad/eslint-config-base-template-es6';
 import unusedImports from 'eslint-plugin-unused-imports';
 import pluginVue from 'eslint-plugin-vue';
-import baseTemplateConfigEs6 from '../es6/eslint.config.js';
 
 export default [
     ...pluginVue.configs['flat/essential'],


### PR DESCRIPTION
Corrects 2 dumb mistakes

 * 1 exporting wrong file as default
 * Importing a relative file when its packaged differently
 
 ```
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/code/node_modules/@sourcetoad/es6/eslint.config.js' imported from /code/node_modules/@sourcetoad/eslint-config-base-template-vue/eslint.config.js
```